### PR TITLE
Sets time when commissioning device, fixes #1

### DIFF
--- a/hacklet.gemspec
+++ b/hacklet.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "slop", "~>3.4.0"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
+  gem.add_development_dependency "timecop"
 end

--- a/lib/hacklet/dongle.rb
+++ b/lib/hacklet/dongle.rb
@@ -176,7 +176,7 @@ module Hacklet
 
       transmit(UpdateTimeRequest.new(:network_id => network_id))
       UpdateTimeAckResponse.read(receive(6))
-      UpdateTimeResponse.read(receive(6))
+      UpdateTimeResponse.read(receive(8))
     end
 
     # Private: Initializes the serial port

--- a/lib/hacklet/dongle.rb
+++ b/lib/hacklet/dongle.rb
@@ -38,16 +38,18 @@ module Hacklet
     def commission
       require_session
 
+      response = nil
       begin
         unlock_network
         Timeout.timeout(30) do
+          @logger.info("Listening for devices ...")
           loop do
-            @logger.info("Listening for devices ...")
             buffer = receive(4)
             buffer += receive(buffer.bytes.to_a[3]+1)
             if buffer.bytes.to_a[1] == 0xa0
               response = BroadcastResponse.read(buffer)
               @logger.info("Found device 0x%x on network 0x%x" % [response.device_id, response.network_id])
+              break
             end
           end
         end
@@ -55,6 +57,8 @@ module Hacklet
       ensure
         lock_network
       end
+
+      update_time(response.network_id) if response
     end
 
     # Public: Selects the network.
@@ -157,6 +161,22 @@ module Hacklet
     def boot_confirm
       transmit(BootConfirmRequest.new)
       BootConfirmResponse.read(receive(6))
+    end
+
+    # Private: Updates the time of a device.
+    #
+    # This must be executed within an open session. I'm guessing it selects the
+    # network.
+    #
+    # network_id - 2 byte identified for the network.
+    #
+    # Returns nothing.
+    def update_time(network_id)
+      require_session
+
+      transmit(UpdateTimeRequest.new(:network_id => network_id))
+      UpdateTimeAckResponse.read(receive(6))
+      UpdateTimeResponse.read(receive(6))
     end
 
     # Private: Initializes the serial port

--- a/lib/hacklet/messages.rb
+++ b/lib/hacklet/messages.rb
@@ -73,6 +73,31 @@ module Hacklet
     uint8 :checksum, :check_value => lambda { calculate_checksum == checksum }
   end
 
+  class UpdateTimeAckResponse < Message
+    endian :big
+
+    uint8  :header, :check_value => lambda { value == 0x02 }
+    uint16 :command, :check_value => lambda { value == 0x4022 }
+    uint8  :payload_length, :check_value => lambda { value == 1 }
+
+    uint8  :data, :check_value => lambda { value == 0x00 }
+
+    uint8  :checksum, :check_value => lambda { calculate_checksum == checksum }
+  end
+
+  class UpdateTimeResponse < Message
+    endian :big
+
+    uint8  :header, :check_value => lambda { value == 0x02 }
+    uint16 :command, :check_value => lambda { value == 0x40a2 }
+    uint8  :payload_length, :check_value => lambda { value == 3 }
+
+    uint16 :network_id
+    uint8  :data, :check_value => lambda { value == 0x00 }
+
+    uint8  :checksum, :check_value => lambda { calculate_checksum == checksum }
+  end
+
   class HandshakeResponse < Message
     endian :big
 
@@ -179,6 +204,19 @@ module Hacklet
     uint32 :data, :initial_value => 0xFCFF0001
 
     uint8 :checksum, :value => :calculate_checksum
+  end
+
+  class TimeUpdateRequest < Message
+    endian :big
+
+    uint8    :header, :initial_value => 0x02
+    uint16   :command, :initial_value => 0x4022
+    uint8    :payload_length, :initial_value => 6
+
+    uint16   :network_id
+    uint32le :time, :initial_value => lambda { Time.now.to_i }
+
+    uint8    :checksum, :value => :calculate_checksum
   end
 
   class HandshakeRequest < Message

--- a/lib/hacklet/messages.rb
+++ b/lib/hacklet/messages.rb
@@ -49,16 +49,16 @@ module Hacklet
     endian :big
 
     uint8  :header, :check_value => lambda { value == 0x02 }
-    uint16  :command, :check_value => lambda { value == 0xA013 }
+    uint16 :command, :check_value => lambda { value == 0xA013 }
     uint8  :payload_length, :check_value => lambda { value == 11 }
 
     uint16 :network_id
     uint64 :device_id
 
     # TODO: Not sure why this is here.
-    uint8 :data
+    uint8  :data
 
-    uint8 :checksum, :check_value => lambda { calculate_checksum == checksum }
+    uint8  :checksum, :check_value => lambda { calculate_checksum == checksum }
   end
 
   class LockResponse < Message
@@ -68,9 +68,9 @@ module Hacklet
     uint16 :command, :check_value => lambda { value == 0xA0F9 }
     uint8  :payload_length, :check_value => lambda { value == 1 }
 
-    uint8be :data, :check_value => lambda { value == 0x00 }
+    uint8 :data, :check_value => lambda { value == 0x00 }
 
-    uint8 :checksum, :check_value => lambda { calculate_checksum == checksum }
+    uint8  :checksum, :check_value => lambda { calculate_checksum == checksum }
   end
 
   class UpdateTimeAckResponse < Message
@@ -105,9 +105,9 @@ module Hacklet
     uint16 :command, :check_value => lambda { value == 0x4003 }
     uint8  :payload_length, :check_value => lambda { value == 1 }
 
-    uint8be :data, :check_value => lambda { value == 0x00 }
+    uint8  :data, :check_value => lambda { value == 0x00 }
 
-    uint8 :checksum, :check_value => lambda { calculate_checksum == checksum }
+    uint8  :checksum, :check_value => lambda { calculate_checksum == checksum }
   end
 
   class AckResponse < Message
@@ -117,17 +117,17 @@ module Hacklet
     uint16 :command, :check_value => lambda { value == 0x4024 }
     uint8  :payload_length, :check_value => lambda { value == 1 }
 
-    uint8be :data, :check_value => lambda { value == 0x00 }
+    uint8  :data, :check_value => lambda { value == 0x00 }
 
-    uint8 :checksum, :check_value => lambda { calculate_checksum == checksum }
+    uint8  :checksum, :check_value => lambda { calculate_checksum == checksum }
   end
 
   class SamplesResponse < Message
     endian :big
 
-    uint8  :header, :check_value => lambda { value == 0x02 }
-    uint16 :command, :check_value => lambda { value == 0x40A4 }
-    uint8  :payload_length
+    uint8    :header, :check_value => lambda { value == 0x02 }
+    uint16   :command, :check_value => lambda { value == 0x40A4 }
+    uint8    :payload_length
 
     uint16   :network_id
     uint16   :channel_id
@@ -155,9 +155,9 @@ module Hacklet
     uint16 :command, :check_value => lambda { value == 0x4023 }
     uint8  :payload_length, :check_value => lambda { value == 1 }
 
-    uint8be :data, :check_value => lambda { value == 0x00 }
+    uint8  :data, :check_value => lambda { value == 0x00 }
 
-    uint8 :checksum, :check_value => lambda { calculate_checksum == checksum }
+    uint8  :checksum, :check_value => lambda { calculate_checksum == checksum }
   end
 
   class BootRequest < Message
@@ -167,7 +167,7 @@ module Hacklet
     uint16 :command, :initial_value => 0x4004
     uint8  :payload_length
 
-    uint8 :checksum, :value => :calculate_checksum
+    uint8  :checksum, :value => :calculate_checksum
   end
 
   class BootConfirmRequest < Message
@@ -177,7 +177,7 @@ module Hacklet
     uint16 :command, :initial_value => 0x4000
     uint8  :payload_length
 
-    uint8 :checksum, :value => :calculate_checksum
+    uint8  :checksum, :value => :calculate_checksum
   end
 
   class UnlockRequest < Message
@@ -190,7 +190,7 @@ module Hacklet
     # TODO: What is this?
     uint32 :data, :initial_value => 0xFCFF9001
 
-    uint8 :checksum, :value => :calculate_checksum
+    uint8  :checksum, :value => :calculate_checksum
   end
 
   class LockRequest < Message
@@ -203,10 +203,10 @@ module Hacklet
     # TODO: What is this?
     uint32 :data, :initial_value => 0xFCFF0001
 
-    uint8 :checksum, :value => :calculate_checksum
+    uint8  :checksum, :value => :calculate_checksum
   end
 
-  class TimeUpdateRequest < Message
+  class UpdateTimeRequest < Message
     endian :big
 
     uint8    :header, :initial_value => 0x02
@@ -230,7 +230,7 @@ module Hacklet
     # TODO: What is this?
     uint16 :data, :initial_value => 0x0500
 
-    uint8 :checksum, :value => :calculate_checksum
+    uint8  :checksum, :value => :calculate_checksum
   end
 
   class SamplesRequest < Message
@@ -245,7 +245,7 @@ module Hacklet
     # TODO: What is this?
     uint16 :data, :initial_value => 0x0A00
 
-    uint8 :checksum, :value => :calculate_checksum
+    uint8  :checksum, :value => :calculate_checksum
   end
 
   class ScheduleRequest < Message
@@ -259,7 +259,7 @@ module Hacklet
     uint8  :channel_id
     array  :schedule, :type => [:uint8], :initial_length => 56
 
-    uint8 :checksum, :value => :calculate_checksum
+    uint8  :checksum, :value => :calculate_checksum
 
     def always_off!
       bitmap = [0x7f]*56

--- a/spec/hacklet/dongle_spec.rb
+++ b/spec/hacklet/dongle_spec.rb
@@ -48,11 +48,15 @@ describe Hacklet::Dongle do
     serial_port.should_receive(:read).and_return([0x02, 0xa0, 0x13, 0x0b].pack('c'*4))
     serial_port.should_receive(:read).and_return([0x66, 0xad, 0xcc, 0x1f, 0x10, 0x00,
       0x00, 0x58, 0x4f, 0x80, 0x8e, 0xa9].pack('c'*12))
-    serial_port.should_receive(:read).and_raise(Timeout::Error)
 
     # Lock Network
     serial_port.should_receive(:write).with([0x02, 0xA2, 0x36, 0x04, 0xFC, 0xFF, 0x00, 0x01, 0x92].pack('c'*9))
     serial_port.should_receive(:read).and_return([0x02, 0xA0, 0xF9, 0x01, 0x00, 0x58].pack('c'*6))
+
+    # Update Time
+    serial_port.should_receive(:write).and_return([0x02, 0x40, 0x22, 0x06, 0x66, 0xAD, 0xdb, 0xb4, 0xa8, 0x51, 0x0b].pack('c'*11))
+    serial_port.should_receive(:read).and_return([0x02, 0x40, 0x22, 0x01, 0x00, 0x63].pack('c'*6))
+    serial_port.should_receive(:read).and_return([0x02, 0x40, 0xA2, 0x03, 0x66, 0xAD, 0x00, 0x2a].pack('c'*8))
 
     serial_port.should_receive(:close)
     serial_port.stub!(:closed?).and_return(false)
@@ -61,7 +65,9 @@ describe Hacklet::Dongle do
     subject.should_receive(:boot_confirm)
 
     subject.open_session do |session|
-      session.commission
+      Timecop.freeze(Time.at(0x51a8b4db)) do
+        session.commission
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'hacklet'
+require 'timecop'


### PR DESCRIPTION
I didn't realize that setting the time on the device was part of the commissioning processing initially. This change adds the required part of the protocol to configure the device.
